### PR TITLE
FEATURE: Make package disable-able via configuration

### DIFF
--- a/Configuration/Settings.Revisions.yaml
+++ b/Configuration/Settings.Revisions.yaml
@@ -1,5 +1,6 @@
 CodeQ:
   Revisions:
+    enabled: true
     compression:
       enabled: false # Enables compression of revision xml content in the database
     revisions:


### PR DESCRIPTION
Introduces a new configuration option that allows disabling the plugin while still being installed. This is not meant to be a public API, but have the case in one project where we want to enable the plugin depending on the context.